### PR TITLE
Bump up Glamor version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "postversion": "git push --tags origin HEAD"
   },
   "dependencies": {
-    "glamor": "^2.20.24",
+    "glamor": "^2.20.25",
     "prop-types": "^15.5.8"
   },
   "devDependencies": {


### PR DESCRIPTION
This will drop React Proptypes warnings since
https://github.com/threepointone/glamor/pull/245 was merged.